### PR TITLE
switched to breadth first recursion

### DIFF
--- a/yahoo_groups_backup/subcommands/scrape_files.py
+++ b/yahoo_groups_backup/subcommands/scrape_files.py
@@ -22,8 +22,8 @@ def command(arguments):
     cli = pymongo.MongoClient(arguments['--mongo-host'], arguments['--mongo-port'])
     db = YahooBackupDB(cli, arguments['<group_name>'])
     scraper = YahooBackupScraper(
-        arguments['<group_name>'], arguments['--driver'], arguments['--login'],
-        arguments['--password'])
+        arguments['<group_name>'], arguments['--driver'], login_email=arguments['--login'],
+        password=arguments['--password'])
 
     for file_info in scraper.yield_walk_files():
         if not db.has_file_entry(file_info['filePath']) or not db.has_file_data(file_info['filePath']):


### PR DESCRIPTION
This changes the recursion to remove the necessity for tabbed browser windows. Instead it processes files first, before loading a new subfolder in the current window. Stale elements from the Splinter API were causing problems previously..

Also fixed named parameters for login and password to the scraper module.
Also fixes login page detection for the '&amp;nbsp;' they seem to have added in the button/input text (to prevent wrapping)

Seems to be working fine for me with these revisions. Most appreciative of this scraper library. Using it now to backup the files for my neighborhood association. All the best, Greg