### PR TITLE
Allow pyyaml version >=3.11 as 3.13 was required for python v3.7+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 docopt==0.6.2
 pymongo==3.2.2
 python-dateutil==2.5.3
-pyyaml==3.11
+pyyaml>=3.11
 requests==2.10.0
 schema==0.5.0
 selenium==2.53.5


### PR DESCRIPTION
I had problems, similar issue to [this thread](https://github.com/tmux-python/tmuxp/issues/399), building against python 3.7, but pyyaml 3.13 worked fine.